### PR TITLE
Add event-driven flow and use it by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,41 +28,53 @@ pip install wafflesbot
 
 ## Usage
 
-wafflesbot provides the `waffles` command which can be run interactively or as a
-cronjob.
+wafflesbot provides the `waffles` command, which can either:
+1. Run as a service and reply to emails received via [JMAP server
+   events][jmap-event-source] (the default)
+2. Run as a script to examine recent emails (such as interactively or via a
+   cronjob)
 
 Environment variables:
 * `JMAP_HOST`: JMAP server hostname
-* `JMAP_USER`: Email account username
-* `JMAP_PASSWORD`: Email account password (likely an app password if 2-factor
-  authentication is enabled with your provider)
+* `JMAP_API_TOKEN`: JMAP account API token
 
 Required arguments:
 * `-m/--mailbox`: Name of the folder to process
 * `-r/--reply-content`: Path to file with an HTML reply message
 
+Optional arguments:
+* `-d/--debug`: Enable debug logging
+* `-l/--limit`: Maximum number of emails replies to send (only valid with
+  `-s/--script`)
+* `-n/--days`: Only process email received this many days ago or newer (only
+  valid with `-s/--script`)
+* `-p/--pretend`: Print messages to standard output instead of sending email
+* `-s/--script`: Set to run as a script instead of an event-driven service
+
 ### Invocation examples
 
-Reply to messages in the "Recruiters" folder with the message in `my-reply.html`:
+Listen for new emails, and reply to unreplied messages that appear in the
+"Recruiters" folder with the message in `my-reply.html`:
+
 ```py
 JMAP_HOST=jmap.example.com \
-JMAP_USER=ness \
-JMAP_PASSWORD=pk_fire \
+JMAP_API_TOKEN=ness__pk_fire \
 waffles \
     --mailbox "Recruiters" \
     --reply-content my-reply.html
 ```
 
-Additional argument examples:
+Run as a script and reply to unreplied messages in the "Recruiters" folder with
+the message in `my-reply.html`:
 
-* Only reply to messages received within the last day:
-  * `waffles -m "Recruiters" -r my-reply.html --days 1` (or `-n`)
-* Send at most 2 emails before exiting:
-  * `waffles -m "Recruiters" -r my-reply.html --limit 2` (or `-l`)
-* Instead of sending mail, print constructed email replies to standard output:
-  * `waffles -m "Recruiters" -r my-reply.html --dry-run` (or `-p`)
-* Log JMAP requests and responses to the debug logger:
-  * `waffles -m "Recruiters" -r my-reply.html --debug` (or `-d`)
+```py
+JMAP_HOST=jmap.example.com \
+JMAP_API_TOKEN=ness__pk_fire \
+waffles \
+    --script \
+    --mailbox "Recruiters" \
+    --reply-content my-reply.html
+```
 
 ## Development
 
@@ -83,6 +95,7 @@ Created from [smkent/cookie-python][cookie-python] using
 [fastmail]: https://fastmail.com
 [gh-actions]: https://github.com/smkent/waffles/actions?query=branch%3Amaster
 [jmap]: https://jmap.io
+[jmap-event-source]: https://jmap.io/spec-core.html#event-source
 [jmapc]: https://github.com/smkent/jmapc
 [logo]: https://raw.github.com/smkent/waffles/master/img/waffles.png
 [poetry]: https://python-poetry.org/docs/#installation

--- a/sseclient.pyi
+++ b/sseclient.pyi
@@ -1,0 +1,31 @@
+from typing import Any, Optional
+
+
+class SSEClient:
+    def __init__(
+        self,
+        url: str,
+        last_id: Optional[str] = None,
+        retry: int = 3000,
+        session: Optional[Any] = None,
+        chunk_size: int = 1024,
+        **kwargs: Any
+    ):
+        pass
+    def __iter__(self) -> SSEClient:
+        pass
+    def __next__(self) -> "Event":
+        pass
+
+class Event:
+    def __init__(
+        self,
+        data: str = "",
+        event: str = "message",
+        id: Optional[str] = None,
+        retry: Optional[str] = None,
+    ):
+        self.data: str
+        self.event: str
+        self.id: str
+        self.retry: str

--- a/tests/method_utils.py
+++ b/tests/method_utils.py
@@ -121,7 +121,7 @@ def make_thread_get_call() -> mock._Call:
     return mock.call(ThreadGet(ids=["Tbeef1"]))
 
 
-def make_thread_get_response() -> ThreadGetResponse:
+def make_thread_get_response(has_email_id: bool = True) -> ThreadGetResponse:
     return ThreadGetResponse(
         account_id="u1138",
         state="2187",
@@ -129,9 +129,7 @@ def make_thread_get_response() -> ThreadGetResponse:
         data=[
             Thread(
                 id="Tbeef1",
-                email_ids=[
-                    "Mdeadbeef",
-                ],
+                email_ids=(["Mdeadbeef"] if has_email_id else []),
             ),
         ],
     )

--- a/tests/method_utils.py
+++ b/tests/method_utils.py
@@ -1,7 +1,9 @@
+import json
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 from unittest import mock
 
+import sseclient
 from jmapc import (
     Address,
     Comparator,
@@ -21,6 +23,8 @@ from jmapc import (
 )
 from jmapc import version as jmapc_version
 from jmapc.methods import (
+    EmailChanges,
+    EmailChangesResponse,
     EmailGet,
     EmailGetResponse,
     EmailQuery,
@@ -42,6 +46,16 @@ from replyowl import version as replyowl_version
 from wafflesbot import version as wafflesbot_version
 
 local_tz_abbrev = datetime(1994, 8, 24, 12, 1, 2).astimezone().strftime("%Z")
+
+
+def make_email_event(
+    email_state: str, id: Optional[str] = None
+) -> sseclient.Event:
+    return sseclient.Event(
+        id=id,
+        event="state",
+        data=json.dumps({"changed": {"u1138": {"email": email_state}}}),
+    )
 
 
 def make_identity_get_response() -> IdentityGetResponse:
@@ -103,6 +117,26 @@ def make_mailbox_get_response(id: str, name: str) -> List[InvocationResponse]:
     ]
 
 
+def make_thread_get_call() -> mock._Call:
+    return mock.call(ThreadGet(ids=["Tbeef1"]))
+
+
+def make_thread_get_response() -> ThreadGetResponse:
+    return ThreadGetResponse(
+        account_id="u1138",
+        state="2187",
+        not_found=[],
+        data=[
+            Thread(
+                id="Tbeef1",
+                email_ids=[
+                    "Mdeadbeef",
+                ],
+            ),
+        ],
+    )
+
+
 def make_thread_search_call() -> mock._Call:
     return mock.call(
         [
@@ -144,22 +178,53 @@ def make_thread_search_response() -> List[InvocationResponse]:
     ]
 
 
-def make_email_get_call() -> mock._Call:
+def make_email_changes_call(since_state: str) -> mock._Call:
+    return mock.call(
+        EmailChanges(
+            since_state=since_state,
+        ),
+        raise_errors=True,
+    )
+
+
+def make_email_changes_response() -> EmailChangesResponse:
+    return EmailChangesResponse(
+        account_id="u1138",
+        old_state="2000",
+        new_state="2001",
+        created=["Mdeadbeef"],
+        updated=[],
+        destroyed=[],
+        has_more_changes=False,
+    )
+
+
+def make_email_get_call(
+    properties: Optional[List[str]] = None,
+    fetch_all_body_values: Optional[bool] = None,
+) -> mock._Call:
     return mock.call(
         EmailGet(
             ids=["Mdeadbeef"],
-            fetch_all_body_values=True,
-            max_body_value_bytes=1024**2,
+            fetch_all_body_values=fetch_all_body_values,
+            max_body_value_bytes=(
+                1024**2 if fetch_all_body_values else None
+            ),
+            properties=properties,
         )
     )
 
 
 def make_email_get_response(
-    is_read: bool, is_in_inbox: bool
+    is_read: bool,
+    is_in_inbox: bool,
+    additional_mailbox: Optional[str] = None,
 ) -> EmailGetResponse:
     mailbox_ids = {"MBX2187": True}
     if is_in_inbox:
         mailbox_ids["MBX1000"] = True
+    if additional_mailbox:
+        mailbox_ids[additional_mailbox] = True
     return EmailGetResponse(
         account_id="u1138",
         state="2187",

--- a/tests/test_jmap.py
+++ b/tests/test_jmap.py
@@ -7,6 +7,7 @@ def test_client() -> None:
     c = JMAPClientWrapper.create_with_api_token(
         host="jmap-api.example.net",
         api_token="ness__pk_fire",
+        mailbox_name="pigeonhole",
         new_email_callback=lambda email: None,
     )
     assert isinstance(c, jmapc.Client)

--- a/tests/test_jmap.py
+++ b/tests/test_jmap.py
@@ -7,5 +7,6 @@ def test_client() -> None:
     c = JMAPClientWrapper.create_with_api_token(
         host="jmap-api.example.net",
         api_token="ness__pk_fire",
+        new_email_callback=lambda email: None,
     )
     assert isinstance(c, jmapc.Client)

--- a/tests/test_waffles.py
+++ b/tests/test_waffles.py
@@ -39,11 +39,20 @@ def wafflesbot() -> Iterable[Waffles]:
 @pytest.fixture
 def mock_request(wafflesbot: Waffles) -> Iterable[mock.MagicMock]:
     request_mock = mock.MagicMock()
-    session_mock = mock.MagicMock(primary_accounts=dict(mail="u1138"))
+    session_mock = mock.MagicMock(
+        primary_accounts=dict(mail="u1138"),
+        event_source_url="https://jmap-example.localhost/events/",
+    )
     with mock.patch.object(
         wafflesbot.client, "_jmap_session", session_mock
     ), mock.patch.object(wafflesbot.client, "request", request_mock):
         yield request_mock
+
+
+@pytest.fixture(autouse=True)
+def mock_events(wafflesbot: Waffles) -> Iterable[mock.MagicMock]:
+    with mock.patch.object(wafflesbot.client, "_events") as events_mock:
+        yield events_mock
 
 
 def assert_or_debug_calls(

--- a/tests/test_waffles.py
+++ b/tests/test_waffles.py
@@ -33,6 +33,7 @@ def wafflesbot() -> Iterable[Waffles]:
                 "for unit testing.<br />"
             ),
             newer_than_days=7,
+            mailbox_name="pigeonhole",
         )
 
 
@@ -130,7 +131,7 @@ def test_wafflesbot(
             mock_responses.append(archive_response)
     mock_request.side_effect = mock_responses
 
-    wafflesbot.run("pigeonhole", limit=1)
+    wafflesbot.run(limit=1, events=False)
     assert_or_debug_calls(mock_request.call_args_list, expected_calls)
     with pytest.raises(StopIteration):
         mock_request()

--- a/wafflesbot/jmap.py
+++ b/wafflesbot/jmap.py
@@ -302,13 +302,13 @@ class JMAPClientWrapper(jmapc.Client):
     ) -> None:
         if not prev_state or not new_state:
             return
+        mailbox = self.mailbox_by_name(self.mailbox_name)
+        if not mailbox:
+            raise Exception(f'No mailbox named "{self.mailbox_name}" found')
         email_changes_response = self.request(
             EmailChanges(since_state=prev_state), raise_errors=True
         )
         assert isinstance(email_changes_response, EmailChangesResponse)
-        mailbox = self.mailbox_by_name(self.mailbox_name)
-        if not mailbox:
-            raise Exception(f'No mailbox named "{self.mailbox_name}" found')
         email_get_changed_response = self.request(
             EmailGet(
                 ids=list(

--- a/wafflesbot/jmap.py
+++ b/wafflesbot/jmap.py
@@ -343,6 +343,8 @@ class JMAPClientWrapper(jmapc.Client):
             for thread in thread_get_response.data
             if len(thread.email_ids) == 1
         ]
+        if not email_ids:
+            return
         result = self.request(
             EmailGet(
                 ids=email_ids,

--- a/wafflesbot/main.py
+++ b/wafflesbot/main.py
@@ -38,10 +38,15 @@ def main() -> None:
         "--dry-run",
         dest="dry_run",
         action="store_true",
-        help=(
-            "Instead of sending email, "
-            "print email API methods to standard output"
-        ),
+        help="Print messages to standard output instead of sending email",
+    )
+    ap.add_argument(
+        "-s",
+        "--script",
+        "--no-events",
+        dest="events",
+        action="store_false",
+        help="Run as a script instead of an event-driven service",
     )
     ap.add_argument(
         "-l",
@@ -51,7 +56,10 @@ def main() -> None:
         metavar="count",
         default=0,
         type=int,
-        help="Maximum number of email replies to send (0 for no limit)",
+        help=(
+            "Maximum number of email replies to send (0 for no limit) (only "
+            "valid with -s/--script) (default: %(default)s)"
+        ),
     )
     ap.add_argument(
         "-n",
@@ -62,8 +70,8 @@ def main() -> None:
         default=1,
         type=int,
         help=(
-            "Only process email received this many days ago or newer "
-            "(default: %(default)s)"
+            "Only process email received this many days ago or newer (only "
+            "valid with -s/--script) (default: %(default)s)"
         ),
     )
 
@@ -77,4 +85,4 @@ def main() -> None:
         newer_than_days=args.newer_than_days,
         mailbox_name=args.mailbox,
     )
-    w.run(limit=args.limit)
+    w.run(limit=args.limit, events=args.events)

--- a/wafflesbot/main.py
+++ b/wafflesbot/main.py
@@ -75,5 +75,6 @@ def main() -> None:
         live_mode=not args.dry_run,
         reply_content=args.reply_content.read(),
         newer_than_days=args.newer_than_days,
+        mailbox_name=args.mailbox,
     )
-    w.run(args.mailbox, limit=args.limit)
+    w.run(limit=args.limit)

--- a/wafflesbot/waffles.py
+++ b/wafflesbot/waffles.py
@@ -1,7 +1,6 @@
 import logging
 import time
-
-# from datetime import timedelta
+from datetime import timedelta
 from typing import Any
 
 from jmapc import Email
@@ -16,31 +15,43 @@ class Waffles:
         self,
         *args: Any,
         reply_content: str,
+        mailbox_name: str,
         newer_than_days: int = 1,
         debug: bool = False,
         **kwargs: Any,
     ):
         self.client = JMAPClientWrapper.create_with_api_token(
-            *args, new_email_callback=self.new_email, **kwargs
+            *args,
+            mailbox_name=mailbox_name,
+            new_email_callback=self._handle_email,
+            **kwargs,
         )
+        self.mailbox_name = mailbox_name
         self.reply_content = reply_content
         self.newer_than_days = newer_than_days
         self._setup_logging()
         log.setLevel(logging.DEBUG if debug else logging.INFO)
 
-    def new_email(self, email: Email) -> None:
-        print("GOT A NEW EMAIL IN WAFFLES")
-        print(email)
+    def run(self, limit: int = 0, events: bool = True) -> None:
+        if events:
+            self.client.process_events()
+        else:
+            self.client.process_recent_emails_without_replies(
+                since=(
+                    timedelta(days=self.newer_than_days)
+                    if self.newer_than_days
+                    else None
+                ),
+                limit=limit,
+            )
+
+    def _handle_email(self, email: Email) -> None:
         print(
-            f"[EVENT] [{email.received_at}] FROM {email.mail_from}: "
+            f"[{email.received_at}] FROM {email.mail_from}: "
             f"{email.subject}"
         )
         self._reply(email)
         self.client.archive_email(email)
-
-    def run(self, mailbox_name: str, limit: int = 0) -> None:
-        self.client.mailbox_name = mailbox_name
-        self.client.process_events()
 
     def _reply(self, email: Email) -> None:
         text_body, html_body, user_agent = compose_reply(


### PR DESCRIPTION
This feature processes emails in a service loop, retrieved via JMAP server events.

The previous script mode is still available using a command line parameter.