### PR TITLE
Update project template cruft, dependencies

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/smkent/cookie-python",
-  "commit": "c6ad7e19de6cbf2f13d0557d16b2dea77b8b3537",
+  "commit": "d839c1da8c8b6bff0bb0b50230b46fc5c309bca8",
   "context": {
     "cookiecutter": {
       "project_name": "wafflesbot",

--- a/poetry.lock
+++ b/poetry.lock
@@ -414,17 +414,17 @@ jinja2 = "*"
 
 [[package]]
 name = "jmapc"
-version = "0.2.10"
+version = "0.2.11"
 description = "JMAP client library for Python"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 
 [package.dependencies]
-dataclasses-json = ">=0.5.6,<0.6.0"
-python-dateutil = ">=2.8.2,<3.0.0"
-requests = ">=2.27.1,<3.0.0"
-sseclient = ">=0.0.27,<0.0.28"
+dataclasses-json = "*"
+python-dateutil = "*"
+requests = "*"
+sseclient = "*"
 
 [[package]]
 name = "markupsafe"
@@ -716,15 +716,15 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "replyowl"
-version = "0.1.7"
+version = "0.1.8"
 description = "Email reply body generator for HTML and text"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 
 [package.dependencies]
-beautifulsoup4 = ">=4.10.0,<5.0.0"
-html2text = ">=2020.1.16,<2021.0.0"
+beautifulsoup4 = "*"
+html2text = "*"
 
 [[package]]
 name = "requests"
@@ -1114,8 +1114,8 @@ jinja2-time = [
     {file = "jinja2_time-0.2.0-py2.py3-none-any.whl", hash = "sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa"},
 ]
 jmapc = [
-    {file = "jmapc-0.2.10-py3-none-any.whl", hash = "sha256:9a0c449c50df6982c14caa77f03aa1d15ca3d2b325490af8ae6c6d87b512146e"},
-    {file = "jmapc-0.2.10.tar.gz", hash = "sha256:978b2cf9be07466f509151d84ad917becd9f64a756dac5e3695249611bdb82b9"},
+    {file = "jmapc-0.2.11-py3-none-any.whl", hash = "sha256:e84f3add8d89bc21c993beb3f619a114fc3680c849d50f30f69a6e9f79143e82"},
+    {file = "jmapc-0.2.11.tar.gz", hash = "sha256:7bf835f1811c52a368ccc55146a9885a9c6f20949d5c51b6a6848d478c65c16d"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
@@ -1322,8 +1322,8 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 replyowl = [
-    {file = "replyowl-0.1.7-py3-none-any.whl", hash = "sha256:d2b0bc888ed42f2d7b5a8781318fa8b248f82af3c1cb10ce16eb9fe5d935ec78"},
-    {file = "replyowl-0.1.7.tar.gz", hash = "sha256:95a9c5f0e6e1bcc6e22e232eb6a15084fd82c69a1522c6ec6fc184f520739d08"},
+    {file = "replyowl-0.1.8-py3-none-any.whl", hash = "sha256:d6e2a8725ce553896583012e78f7d243a922bdec2309844f1c2931ee0088227c"},
+    {file = "replyowl-0.1.8.tar.gz", hash = "sha256:85dfc4b82b2deedce5932a714abd85e583f70dd76cc7e7715b0bcc446b8574f3"},
 ]
 requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},


### PR DESCRIPTION
Applied updates from upstream project template commits:

https://github.com/smkent/cookie-python/compare/c6ad7e19de6cbf2f13d0557d16b2dea77b8b3537...d839c1da8c8b6bff0bb0b50230b46fc5c309bca8

```
* d839c1d Merge pull request #72 from smkent/updates
* 8be2dee Update pre-commit plugins
* 02be331 Update dependencies, unpin poetry-dynamic-versioning version
```

Updated project dependencies via `poetry update`:

Package operations: 0 installs, 2 updates, 0 removals

- Updating jmapc (0.2.10 -> 0.2.11)
- Updating replyowl (0.1.7 -> 0.1.8)